### PR TITLE
Add login unsuccessful case

### DIFF
--- a/Assets/Scripts/SignOnButton.cs
+++ b/Assets/Scripts/SignOnButton.cs
@@ -55,7 +55,12 @@ public class SignOnButton : MonoBehaviour {
     } else if (task.IsCanceled) {
       AddStatusText ("Canceled");
     } else { // Google auth success
-      userInfo = new UserInfo { gid = task.Result.UserId, displayName = task.Result.DisplayName };
+      userInfo = new UserInfo
+      {
+        gid = task.Result.UserId,
+        displayName = task.Result.DisplayName,
+        idToken = task.Result.IdToken
+      };
 
       // Send user info to check if existing mathgo user
       StartCoroutine (CheckUserExists ());
@@ -82,9 +87,13 @@ public class SignOnButton : MonoBehaviour {
       userInfo.avatar = responseUserInfo.avatar;
       userInfo.existingUser = responseUserInfo.existingUser;
 
-      if (userInfo.existingUser) {
-        //AddStatusText("Existing user: " + userInfo.displayName);
-
+      if (!userInfo.loginSuccessful)
+      {
+        // TODO Handle unsuccessful login
+        Debug.Log ("Invalid login");
+        AddStatusText ("Login unsuccessful");
+      }
+      else if (userInfo.existingUser) {
         // Loading up user data into game manager, and loading new scene
         loader.GetComponent<GameManager> ().charType = userInfo.avatar;
         SceneManager.LoadScene (1);

--- a/Assets/Scripts/SignOnButton.cs
+++ b/Assets/Scripts/SignOnButton.cs
@@ -86,6 +86,7 @@ public class SignOnButton : MonoBehaviour {
       UserInfo responseUserInfo = JsonUtility.FromJson<UserInfo> (response);
       userInfo.avatar = responseUserInfo.avatar;
       userInfo.existingUser = responseUserInfo.existingUser;
+      userInfo.loginSuccessful = responseUserInfo.loginSuccessful;
 
       if (!userInfo.loginSuccessful)
       {

--- a/Assets/Scripts/UserInfo.cs
+++ b/Assets/Scripts/UserInfo.cs
@@ -7,4 +7,6 @@ public class UserInfo
     public bool existingUser;
     public int avatar;
     public string displayName;
+    public string idToken;
+    public bool loginSuccessful;
 }


### PR DESCRIPTION
Background on changes:

We have two login outcomes where both is for a successful Google sign in (1. new or 2. existing Math Go user). This PR is for adding a third case login case that leads to an unsuccessful sign in due to an invalid or missing user token.