### PR TITLE
Attach camera to player instance

### DIFF
--- a/Assets/Scenes/OverworldMap.unity
+++ b/Assets/Scenes/OverworldMap.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1210,6 +1210,7 @@ MonoBehaviour:
     type: 3}
   character2: {fileID: 3287661613510392533, guid: 1a787478c7654f54ca7e5005a0c6c433,
     type: 3}
+  mainCamera: {fileID: 8030623}
 --- !u!4 &1990140692
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/OverworldManager.cs
+++ b/Assets/Scripts/OverworldManager.cs
@@ -8,6 +8,7 @@ public class OverworldManager : MonoBehaviour
 {
     [SerializeField] private GameObject character1;
     [SerializeField] private GameObject character2;
+    [SerializeField] private Camera mainCamera;
     private GameManager gameManager;
     private GameObject player;
     private float MIN_RANGE = -5.0f;
@@ -41,6 +42,7 @@ public class OverworldManager : MonoBehaviour
         player.transform.parent = LBG.transform;
         // Slime model tiny - using this to increase size
         player.transform.localScale += new Vector3(3.0f, 3.0f, 3.0f);
+        mainCamera.transform.parent = player.transform;
     }
 
     private void PopulateMapWithBeasties()


### PR DESCRIPTION
Camera now moves with the player. This version of Mapbox did not seem to have a script for drag rotation. RotateWithLocationProvider will face wherever your character is facing.